### PR TITLE
added a before_filter in the readings controller in order to find the…

### DIFF
--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -1,64 +1,59 @@
 class ReadingsController < ApplicationController
 
-	def edit
+  before_filter :find_car
 
-		@car = Car.find(params[:car_id])
-		@reading = Reading.find(params[:id])
+  def edit
+    @reading = @car.readings.find(params[:id])
+  end
 
-	end
+  def update
+    @reading = @car.readings.find(params[:id])
 
-	def update
+    if @reading.update_attributes(reading_params)
 
-		@car = Car.find(params[:car_id])
-		@reading = Reading.find(params[:id])
+      #redirect_to(:action => 'show', :id => @reading.id)
+      redirect_to "/cars/"+@car.id.to_s
+    end
 
-		if @reading.update_attributes(reading_params)
+  end
 
-			#redirect_to(:action => 'show', :id => @reading.id)
-			redirect_to "/cars/"+@car.id.to_s
-		end
-
-	end
-
-	def new
-		@car = Car.find(params[:car_id])
-    	@new_reading = Reading.new
-    	@new_reading.car_id = @car.id
-  	end
+  def new
+    @new_reading = @car.readings.new
+  end
   
-  	def create
-  		#@car = Car.find(params[:car_id])
-   		@reading = Reading.new(reading_params)
-   		@reading.car_id = params[:car_id]
-    	if @reading.save
-    		#flash[:notice] = "The reading has been created."
-    		redirect_to '/cars/'+@reading.car_id.to_s
-    	else
-    		#flash[:notice] = "The reading did not save."
-      		render 'new'
-    	end
-  	end
+  def create
+    @reading = @car.readings.new(reading_params)
+    if @reading.save
+      #flash[:notice] = "The reading has been created."
+      redirect_to '/cars/'+@reading.car_id.to_s
+    else
+      #flash[:notice] = "The reading did not save."
+        render 'new'
+    end
+  end
 
-  	def destroy
-		#find the reading using params id
-   		@reading = Reading.find(params[:id])
-   		#delete the reading from the database
-   		if @reading.destroy
-    		#flash[:notice] = "The reading has been created."
-    		redirect_to '/cars/'+ params[:car_id].to_s
-    	else
-    		#flash[:notice] = "The reading did not save."
-      		redirect_to root_path
-    	end
+  def destroy
+  #find the reading using params id
+    @reading = @car.readings.find(params[:id])
+    #delete the reading from the database
+    if @reading.destroy
+      #flash[:notice] = "The reading has been created."
+      redirect_to '/cars/'+ params[:car_id].to_s
+    else
+      #flash[:notice] = "The reading did not save."
+        redirect_to root_path
+    end
 
-  	end
+  end
 
 
-	private
+  private
 
-	def reading_params
+  def find_car
+    @car = Car.find(params[:car_id])
+  end
 
-		params.require(:reading).permit(:date, :odo, :fuel_vol, :fuel_cost, :car_id)
-
-	end
+  def reading_params
+    params.require(:reading).permit(:date, :odo, :fuel_vol, :fuel_cost, :car_id)
+  end
 end


### PR DESCRIPTION
… car each time without having to explicitly do so. Removes code which is nice but sometimes you need to be careful putting in too many beffore_fitlers. It's a common pattern though for a controller / resource embedded within another resource. Once we have the @car object we can reference the readings from the @car object. This is definitely safer. If Mickey 1 was to find the number of a reading of Mickey 3's then Mickey 3 might be happy. But by finding the reading from the @car object, it means that Rails will through an exception if it can't find the reading belonging to the @car. So if Mickey 1 doesn't have access to Mickey 3's car, then Mickey 1 will also not be able to access Mickey 3's readings
